### PR TITLE
Fixing fednet id not set in compute form

### DIFF
--- a/src/components/ComputeForm.js
+++ b/src/components/ComputeForm.js
@@ -274,13 +274,15 @@ class ComputeForm extends Component {
               </select>
 
               <label>Federated Network ID</label>
-              <select value={this.props.federatedNetworkId} onChange={this.handleChange}
+              <select value={this.state.federatedNetworkId} onChange={this.handleChange}
                       name='federatedNetworkId' className="form-control">
                 <option value=''>Choose a federated network</option>
                 {
                   this.props.fednets.loading ?
                   this.props.fednets.data.map((network, idx) =>
-                    <option key={idx} value={network.instanceId}>{network.instanceId}</option>) :
+                    <option key={idx} value={network.instanceId}>
+                      {network.instanceName.concat(' (', network.instanceId, ')')}
+                    </option>) :
                   undefined
                 }
               </select>

--- a/src/defaults/api.config.js
+++ b/src/defaults/api.config.js
@@ -1,5 +1,5 @@
 export const env = {
-  fns: 'http://localhost:8083',
+  fns: 'http://localhost:8093',
   ras: 'http://localhost:8081',
   ms: 'http://localhost:8082',
   as: 'http://localhost:8080',

--- a/src/defaults/api.config.js
+++ b/src/defaults/api.config.js
@@ -1,5 +1,5 @@
 export const env = {
-  fns: 'http://localhost:8093',
+  fns: 'http://localhost:8083',
   ras: 'http://localhost:8081',
   ms: 'http://localhost:8082',
   as: 'http://localhost:8080',


### PR DESCRIPTION
Fixes a bug where the fednet id would not be cleared out when closing the
create compute form. Also, adding the fednet name to the dropdown list.