### PR TITLE
Create Dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: '08:00'
+  open-pull-requests-limit: 10
+  target-branch: develop


### PR DESCRIPTION
This pull request creates a config file to integrate the dependabot to this repository. 

The Dependabot is [moving natively](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) to GitHub.